### PR TITLE
attribute before function/procedure visibility

### DIFF
--- a/Parse/BuildParseTree.pas
+++ b/Parse/BuildParseTree.pas
@@ -4278,6 +4278,13 @@ begin
       lc := fcTokenList.FirstSolidToken;
     end;
 
+	{ attribute then visibility then procedure/function }
+    if lc.TokenType in (ClassVisibility) then
+    begin
+      RecogniseClassVisibility();
+      lc := fcTokenList.FirstSolidToken;
+    end;
+
     case lc.TokenType of
     ttProcedure:
       RecogniseProcedureHeading(False, True);

--- a/test.pas
+++ b/test.pas
@@ -11,6 +11,11 @@ type
     ['{5E3C2BCA-56C8-46DE-959F-338AF5F69C1A}']
     procedure proc;
   end;
+  
+type TMyType = class
+  [Subscribe]
+  protected procedure proce(var params: TParams);
+end;  
 
 implementation
 


### PR DESCRIPTION
Base repo parser supports this
```pascal
type TMyType = class
  protected
  [Subscribe]
  procedure proce(var params: TParams);
end; 
```
this pull request also supports
```pascal
type TMyType = class
  [Subscribe]
  protected procedure proce(var params: TParams);
end; 
```