### PR TITLE
manage list of inline variables w/o infered type

### DIFF
--- a/Parse/BuildParseTree.pas
+++ b/Parse/BuildParseTree.pas
@@ -2282,7 +2282,8 @@ begin
   // with type inference
   if inlineVar then
   begin
-    RecogniseIdentifier(false, idAllowDirectives);
+	// fix: inline list of variables
+    RecogniseIdentList(False);
     if fcTokenList.FirstSolidTokenType in AssignmentDirectives then
     begin
       // variable declaration with infered type

--- a/test.pas
+++ b/test.pas
@@ -31,6 +31,12 @@ function myFunction(aParam: string
 var i: integer;
 begin
   var inline_var_decl := 777;
+
+  // case for fix: inline list of variables
+     var inline_var_decl2,         inline_var_decl3: string;
+           var inline_var_decl5,             inline_var_decl6 := 888;
+var inline_var_decl2_string,         inline_var_decl3_string: string :=    'this is a string';		   
+
   for i := 1 to 10 do
     if i < 10 then write(i, ',')
       else writeln(i);


### PR DESCRIPTION
This fix adds support for list of inline variables with or without explicit type, with or without assigned value.
See new bad formatted lines into `test.pas`.