### PR TITLE
fix parse delphi 2005 for loop

### DIFF
--- a/Parse/BuildParseTree.pas
+++ b/Parse/BuildParseTree.pas
@@ -2293,6 +2293,16 @@ begin
   end
   else
     RecogniseIdentList(False);
+
+  // check if we are inside a for loop header
+  lc := fcTokenList.FirstSolidToken;
+  if lc.TokenType = ttIn then
+  begin
+    // Delphi 2005 syntax
+    PopNode;
+    Exit;
+  end;	
+	
   Recognise(ttColon);
   RecogniseType;
 

--- a/test.pas
+++ b/test.pas
@@ -36,6 +36,11 @@ begin
 var inline_var_decl2_string,  inline_var_decl3_string: string :=  'this is a string';
 
  const inline_const := 999;
+ 
+   for var currentField in fieldList do
+  begin
+                var inline_var_decl4: string = 'a string';
+	 end;
 
   for i := 1 to 10 do
     if i < 10 then write(i, ',')


### PR DESCRIPTION
Fix for parsing statements like
`
for var currentField in fieldList do
`
Function `RecogniseVarDecl` should exit if finds `in` before searching for `:`.